### PR TITLE
Make default config only work for certain managers, as before

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -3,19 +3,22 @@
   "extends": [
     "config:base",
     "schedule:weekdays",
-    ":automergeBranch",
-    ":automergeDigest",
-    ":automergeMinor",
-    ":automergePatch",
     ":disableDependencyDashboard",
     ":enablePreCommit"
   ],
   "commitMessageAction": "Renovate:",
   "packageRules": [
     {
+      "description": "Automatically merge minor and patch-level updates",
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": ["github-actions", "pre-commit"]
+    },
+    {
       "description": "Shorten commit titles",
       "commitMessageTopic": "{{depName}}",
-      "matchManagers": ["bundler", "github-actions", "pre-commit"]
+      "matchManagers": ["github-actions", "pre-commit"]
     }
   ]
 }

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -12,7 +12,7 @@
       "description": "Automatically merge minor and patch-level updates",
       "automerge": true,
       "automergeType": "branch",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchUpdateTypes": ["digest", "minor", "patch"],
       "matchManagers": ["github-actions", "pre-commit"]
     },
     {


### PR DESCRIPTION
This was the config in `UCL-ARC/renovate-config` and I accidentally replaced it with my own. Was bound to make a mistake somewhere.

Essentially, for now, only do automerging for `pre-commit`/`github-actions`.