### PR TITLE
Add `dockerfile` manager to @renovatebot

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -15,7 +15,7 @@
     {
       "description": "Automatically merge, minor and patch-level updates",
       "automerge": true,
-      "matchManagers": ["github-actions", "pre-commit"],
+      "matchManagers": ["dockerfile", "github-actions", "pre-commit"],
       "matchUpdateTypes": ["digest", "minor", "patch"]
     },
     {


### PR DESCRIPTION
Now that we are using hashed versions (`config:best-practices`), this would greatly reduce noise and should be safe. Manager config: https://docs.renovatebot.com/modules/manager/dockerfile.