### PR TITLE
Allow `terraform` to autoupdate

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -15,7 +15,12 @@
     {
       "description": "Automatically merge, minor and patch-level updates",
       "automerge": true,
-      "matchManagers": ["dockerfile", "github-actions", "pre-commit"],
+      "matchManagers": [
+        "dockerfile",
+        "github-actions",
+        "pre-commit",
+        "terraform"
+      ],
       "matchUpdateTypes": ["digest", "minor", "patch"]
     },
     {


### PR DESCRIPTION
Used extensively in @UCL-MIRSG and deemed safe enough to add to the list