### PR TITLE
Add Safe-Settings app to manage policy as code

### DIFF
--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -1,0 +1,66 @@
+---
+name: Safe Settings Sync
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - safe-settings/**
+      - .github/workflows/safe-settings.yaml
+  schedule:
+    - cron: 0 */4 * * *
+  workflow_dispatch: {}
+
+concurrency:
+  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  safe-settings-sync:
+    runs-on: ubuntu-latest
+    env:
+      SAFE_SETTINGS_VERSION: 2.1.14
+      SAFE_SETTINGS_CODE_DIR: .safe-settings-code
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Checkout GitHub Safe-Settings repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          path: ${{ env.SAFE_SETTINGS_CODE_DIR }}
+          ref: ${{ env.SAFE_SETTINGS_VERSION }}
+          repository: github/safe-settings
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          cache-dependency-path:
+            ${{ env.SAFE_SETTINGS_CODE_DIR }}/package-lock.json
+          cache: npm
+          node-version-file: ${{ env.SAFE_SETTINGS_CODE_DIR }}/.nvmrc
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ${{ env.SAFE_SETTINGS_CODE_DIR }}
+
+      - name: Run application
+        run: npm run full-sync
+        working-directory: ${{ env.SAFE_SETTINGS_CODE_DIR }}
+        env:
+          ADMIN_REPO: .github
+          APP_ID: ${{ vars.SAFE_SETTINGS_APP_ID }}
+          BLOCK_REPO_RENAME_BY_HUMAN: false
+          CONFIG_PATH: safe-settings
+          DEPLOYMENT_CONFIG_FILE:
+            ${{ github.workspace }}/safe-settings/deployment.yaml
+          ENABLE_PR_COMMENT: true
+          GH_ORG: ${{ vars.SAFE_SETTINGS_GH_ORG }}
+          GITHUB_CLIENT_ID: ${{ vars.SAFE_SETTINGS_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET:
+            ${{ secrets.SAFE_SETTINGS_GITHUB_CLIENT_SECRET }}
+          LOG_LEVEL: trace
+          PRIVATE_KEY: ${{ secrets.SAFE_SETTINGS_PRIVATE_KEY }}
+          SETTINGS_FILE_PATH: organisation.yaml

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,4 +5,14 @@
     ":assignAndReview(paddyroddy)",
     ":automergeAll",
   ],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Update GitHub Safe-Settings version",
+      fileMatch: [".github/workflows/safe-settings.yaml$"],
+      matchStrings: ["SAFE_SETTINGS_VERSION:\\s(?<currentValue>.*)"],
+      depNameTemplate: "github/safe-settings",
+      datasourceTemplate: "github-releases",
+    },
+  ],
 }

--- a/safe-settings/README.md
+++ b/safe-settings/README.md
@@ -1,0 +1,60 @@
+# Safe-Settings
+
+[Safe-Settings](https://github.com/github/safe-settings) is a way to manage
+policy-as-code and apply repository settings across the organisation. A
+[GitHub App](https://github.com/apps/arc-safe-settings) has been set up which
+the [GitHub Action](../.github/workflows/safe-settings.yaml) uses to apply the
+settings on a cron schedule. The settings here are a reduced set used in the
+[https://github.com/UCL-MIRSG/.github repository](https://github.com/UCL-MIRSG/.github/tree/main/safe-settings).
+
+## Configuration Files
+
+There are four types of settings that can be applied:
+
+- [Deployment](https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/sample-deployment-settings.yml)
+  which defines deployment and runtime settings.
+- [Organisation](https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/settings.yml)
+  which can be used to define org-level settings.
+- [Repository](https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/repo.yml)
+  which can be used to define repo-level settings.
+- [Suborganisation](https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/suborg.yml)
+  which can be used to define suborganisation-level settings.
+
+Beyond these example configurations one can read more about potential settings
+to apply in the
+[documentation](https://github.com/github/safe-settings/tree/main-enterprise/docs/github-settings).
+The precedence order for configuration is `repository` > `suborganisation` >
+`organisation`.
+
+## The Settings in This Repository
+
+### Deployment
+
+The [deployment settings](deployment.yaml) are used to exclude archived
+repositories from the Safe-Settings app. This is because these repositories are
+read-only and hence cannot be modified. Rather than having the GitHub Action
+fail on these repositories, they are excluded from the run.
+
+### Organisation
+
+The [organisation settings](organisation.yaml) are used to define general
+repository settings for all repositories across the organisation. These settings
+are applied to all repositories unless the precedence order is overridden by the
+suborganisation settings (or repository settings).
+
+### Suborganisation
+
+The [suborganisation settings](suborgs/rulesets.yaml) are being used to define
+[rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+for all repositories across the organisation. The `rulesets` available in the
+organisation settings are defined for the organisation itself rather than
+individual repositories, so they cannot be set via organisation settings. This
+hack is done through
+
+```yaml
+suborgrepos:
+  - "*"
+```
+
+at the top of the file. Further explanation can be found in the
+[Safe-Settings issues](https://github.com/github/safe-settings/issues/553#issuecomment-2552578978).

--- a/safe-settings/deployment.yaml
+++ b/safe-settings/deployment.yaml
@@ -1,0 +1,18 @@
+# https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/sample-deployment-settings.yml
+---
+restrictedRepos:
+  # these repos are all archived and will cause the GHA to fail
+  # https://github.com/github/safe-settings/issues/443
+  exclude:
+    - ^2024-05-15-UCL-software-carpentry$
+    - ^2024-11-05-python-cell-bio$
+    - ^arc-harvester-tfc-agent$
+    - ^arc-tf-condenser-mgmt$
+    - ^Book-of-TREx$
+    - ^ENERGETIC$
+    - ^ioe-student-school-allocation$
+    - ^IoN-DRI-MRI$
+    - ^packer-rhel-dependant$
+    - ^packer-rhel-postgresql$
+    - ^test-migrated-wiki$
+    - ^TREx$

--- a/safe-settings/organisation.yaml
+++ b/safe-settings/organisation.yaml
@@ -1,0 +1,11 @@
+# https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/settings.yml
+---
+autolinks:
+  - key_prefix: ARCMYS-
+    url_template: https://myservices-arc.uk.4me.com/requests/<num>
+    is_alphanumeric: false
+
+repository:
+  allow_auto_merge: true
+  allow_update_branch: true
+  delete_branch_on_merge: true

--- a/safe-settings/suborgs.yaml/rulesets.yaml
+++ b/safe-settings/suborgs.yaml/rulesets.yaml
@@ -1,0 +1,19 @@
+# https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/suborg.yml
+# ---
+# suborgrepos:
+#   - "*"
+
+# rulesets:
+#   - name: Default
+#     target: branch
+#     enforcement: active
+
+#     conditions:
+#       ref_name:
+#         include:
+#           - ~DEFAULT_BRANCH
+#         exclude: []
+
+#     rules:
+#       - type: deletion
+#       - type: non_fast_forward # prevents force pushes


### PR DESCRIPTION
This is copying the work across in the @UCL-MIRSG organisation here https://github.com/UCL-MIRSG/.github/pull/141 relating to the deployment of the https://github.com/github/safe-settings app. I recently gave a brief overview of this in the [DevOps Hour slides](https://paddyroddy.github.io/talks/turbocharging-your-github-organisation/#/6). I have [created an app with the appropriate permissions](https://github.com/organizations/UCL-ARC/settings/apps/arc-safe-settings), which will need to be installed organisation wide once this PR is merged.

Safe-Settings has a lot of possible options, so I've gone for as little inoffensive ones as possible. These are currently:
- [allow_auto_merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
- [allow_update_branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-suggestions-to-update-pull-request-branches)
- [delete_branch_on_merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches)
- `ARCMYS-` [autolink](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources) - this was @HChughtai's idea allowing one to easily refer to a MyServices URL by the number, i.e. ARCMYS-1617131.