### PR TITLE
Make @renovatebot wait until status checks have completed

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -8,7 +8,8 @@
     ":disableDependencyDashboard",
     ":enablePreCommit",
     ":label(renovate)",
-    ":prHourlyLimitNone"
+    ":prHourlyLimitNone",
+    ":prNotPending"
   ],
   "commitMessageAction": "Renovate:",
   "packageRules": [


### PR DESCRIPTION
> When you get the PR notification, you can take action immediately, as you have the full test results. If there are no checks associated, Renovate will create the PR once 24 hours have elapsed since creation of the commit.

See discussion here https://github.com/renovatebot/renovate/discussions/32829#discussioncomment-11426575. `internalChecksFilter` is now `strict` by default.