### PR TITLE
Tidy up update types

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -14,7 +14,7 @@
   "commitMessageAction": "Renovate:",
   "packageRules": [
     {
-      "description": "Automatically merge diest, minor and patch-level updates",
+      "description": "Automatically merge digest, minor and patch-level updates",
       "automerge": true,
       "matchManagers": [
         "dockerfile",

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -43,7 +43,7 @@
       "description": "Only allow major updates",
       "enabled": false,
       "matchDepNames": ["renovatebot/pre-commit-hooks"],
-      "matchUpdateTypes": ["minor", "patch", "pin"]
+      "matchUpdateTypes": ["digest", "minor", "patch"]
     },
     {
       "description": "Support loose versioning",

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -14,7 +14,7 @@
   "commitMessageAction": "Renovate:",
   "packageRules": [
     {
-      "description": "Automatically merge, minor and patch-level updates",
+      "description": "Automatically merge diest, minor and patch-level updates",
       "automerge": true,
       "matchManagers": [
         "dockerfile",


### PR DESCRIPTION
I think this was a mistake in the solution I got when asking a question on @renovatebot. It should have been `digest` rather than `pin`.