### PR TITLE
Bump all GitHub Actions to latest semver

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: ./actions/links
         with:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: ./actions/linting
         with:

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Bump version and push tag
         id: bump-version
-        # yamllint disable-line rule:line-length
         uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -22,14 +22,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Bump version and push tag
         id: bump-version
         # yamllint disable-line rule:line-length
-        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # v1
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,9 @@ repos:
                 indentation: enable,
                 key-duplicates: enable,
                 key-ordering: disable,
-                line-length: enable,
+                line-length: {
+                  max: 93
+                },
                 new-line-at-end-of-file: enable,
                 new-lines: enable,
                 octal-values: enable,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
             }
           - --strict
   - repo: https://github.com/crate-ci/typos
-    rev: v1.46.3
+    rev: v1.47.2
     hooks:
       - id: typos
         args:
@@ -63,8 +63,8 @@ repos:
     rev: v1.5.6
     hooks:
       - id: forbid-tabs
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
     hooks:
       - id: prettier
         args:
@@ -89,7 +89,7 @@ repos:
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.25.0
+    rev: 43.214.6
     hooks:
       - id: renovate-config-validator
         args:

--- a/actions/add-to-project/action.yml
+++ b/actions/add-to-project/action.yml
@@ -29,14 +29,14 @@ runs:
     - name: Generate token
       id: generate-token
       # yamllint disable-line rule:line-length
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-pem }}
 
     - name: Get project data
       # yamllint disable-line rule:line-length
-      uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         github-token: ${{ steps.generate-token.outputs.token }}
         label-operator: ${{ inputs.label-operator }}

--- a/actions/add-to-project/action.yml
+++ b/actions/add-to-project/action.yml
@@ -28,14 +28,12 @@ runs:
   steps:
     - name: Generate token
       id: generate-token
-      # yamllint disable-line rule:line-length
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-pem }}
 
     - name: Get project data
-      # yamllint disable-line rule:line-length
       uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         github-token: ${{ steps.generate-token.outputs.token }}

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -17,11 +17,11 @@ runs:
   using: composite
   steps:
     - name: Checkout source
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Check links
       # yamllint disable-line rule:line-length
-      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         args: ${{ inputs.lychee-args }}
         failIfEmpty: false

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -20,7 +20,6 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Check links
-      # yamllint disable-line rule:line-length
       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         args: ${{ inputs.lychee-args }}

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -11,16 +11,16 @@ runs:
   using: composite
   steps:
     - name: Checkout source
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Cache pre-commit
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pre-commit
         key: cache-${{ hashFiles(inputs.pre-commit-config) }}
 
     - name: Set up python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.x
 

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -11,6 +11,7 @@ runs:
   using: composite
   steps:
     - name: Checkout source
+      # yamllint disable-line rule:line-length
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Cache pre-commit

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -11,7 +11,6 @@ runs:
   using: composite
   steps:
     - name: Checkout source
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Cache pre-commit
@@ -33,6 +32,5 @@ runs:
       shell: bash
       run: pre-commit run --all-files --color always --verbose
 
-    # yamllint disable-line rule:line-length
     - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       if: ${{ !cancelled() }}


### PR DESCRIPTION
Think immutable releases may become more common so may as well prepare for that

https://astral.sh/blog/open-source-security-at-astral

