### PR TITLE
Fix actions with `checkout` from other repo

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - uses: ./actions/links
         with:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - uses: ./actions/linting
         with:

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - name: Bump version and push tag
         id: bump-version

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -18,6 +18,9 @@ runs:
   steps:
     - name: Checkout source
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: ${{ github.ref }}
+        repository: ${{ github.repository }}
 
     - name: Check links
       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -12,6 +12,9 @@ runs:
   steps:
     - name: Checkout source
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: ${{ github.ref }}
+        repository: ${{ github.repository }}
 
     - name: Cache pre-commit
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
This should make things more safe when using these composite actions in another repo
